### PR TITLE
Added $HOSTNAME to config

### DIFF
--- a/run.py
+++ b/run.py
@@ -107,6 +107,8 @@ def run(args):
         logging.debug(f"Data directory {i + 1} set as {d}")
         assert d is not None, "Data directory is none, which means it failed to resolve. Check the error message above for why."
 
+    logging.info(f"Running on: {os.environ.get('HOSTNAME', '$HOSTNAME not set')} login node.")
+
     manager = Manager(config_filename, yaml_path, config, message_store)
     if args.start is not None:
         args.refresh = True


### PR DESCRIPTION
(usually) the second line of the pippin log will contain the $HOSTNAME, I.e. `Running on: midway2-login1.rcc.local login node.` Fix for #61 